### PR TITLE
Remove build status indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 HTML Sanitization
 =================
 
-[![Build Status](https://travis-ci.org/notriddle/ammonia.svg?branch=master)](https://travis-ci.org/notriddle/ammonia)
 [![Crates.IO](https://img.shields.io/crates/v/ammonia.svg)](https://crates.rs/crates/ammonia)
 ![Requires rustc 1.24.0](https://img.shields.io/badge/rustc-1.24.0+-green.svg)
 


### PR DESCRIPTION
1. It was out of date
2. As long as we use bors it will always be green