### PR TITLE
feature: whitelist generic attribute prefix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2902,8 +2902,10 @@ mod test {
         let prefix_data = "data-";
         let prefix_code = "code-";
         let mut b = Builder::new();
+        let mut hs = HashSet::new();
+        hs.insert(prefix_data);
         assert_eq!(b.allowed_generic_attribute_prefix.is_none(), true);
-        b.add_allowed_generic_attribute_prefix(&prefix_data);
+        b.allowed_generic_attribute_prefix(hs);
         assert_eq!(b.allowed_generic_attribute_prefix.is_some(), true);
         assert_eq!(b.allowed_generic_attribute_prefix.as_ref().unwrap().len(), 1);
         b.add_allowed_generic_attribute_prefix(&prefix_data);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1005,7 +1005,7 @@ impl<'a> Builder<'a> {
         self
     }
 
-    /// Add additonal whitelisted attribute prefix without overwriting old ones.
+    /// Add additional whitelisted attribute prefix without overwriting old ones.
     ///
     /// # Examples
     ///
@@ -2972,17 +2972,26 @@ mod test {
 
     #[test]
     fn generic_attribute_prefixes_clean() {
-        let fragment = "<a data-foo=\"text/javascript\"><a>Hello!</a></a>";
+        let fragment = r#"<a data-1 data-2 code-1 code-2><a>Hello!</a></a>"#;
         let result_cleaned = String::from(
             Builder::new()
+                .add_tag_attributes("a", &["data-1"])
                 .clean(fragment),
         );
-        assert_eq!(result_cleaned, "<a rel=\"noopener noreferrer\"></a><a rel=\"noopener noreferrer\">Hello!</a>");
+        assert_eq!(result_cleaned, r#"<a data-1="" rel="noopener noreferrer"></a><a rel="noopener noreferrer">Hello!</a>"#);
         let result_allowed = String::from(
             Builder::new()
+                .add_tag_attributes("a", &["data-1"])
                 .add_generic_attribute_prefixes(&["data-"])
                 .clean(fragment),
         );
-        assert_eq!(result_allowed, "<a data-foo=\"text/javascript\" rel=\"noopener noreferrer\"></a><a rel=\"noopener noreferrer\">Hello!</a>");
+        assert_eq!(result_allowed, r#"<a data-1="" data-2="" rel="noopener noreferrer"></a><a rel="noopener noreferrer">Hello!</a>"#);
+        let result_allowed = String::from(
+            Builder::new()
+                .add_tag_attributes("a", &["data-1", "code-1"])
+                .add_generic_attribute_prefixes(&["data-", "code-"])
+                .clean(fragment),
+        );
+        assert_eq!(result_allowed, r#"<a data-1="" data-2="" code-1="" code-2="" rel="noopener noreferrer"></a><a rel="noopener noreferrer">Hello!</a>"#);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,6 +279,7 @@ pub struct Builder<'a> {
     allowed_classes: HashMap<&'a str, HashSet<&'a str>>,
     strip_comments: bool,
     id_prefix: Option<&'a str>,
+    allowed_attribute_prefix: Option<HashSet<&'a str>>,
 }
 
 impl<'a> Default for Builder<'a> {
@@ -398,6 +399,7 @@ impl<'a> Default for Builder<'a> {
             allowed_classes,
             strip_comments: true,
             id_prefix: None,
+            allowed_attribute_prefix: None,
         }
     }
 }
@@ -976,6 +978,36 @@ impl<'a> Builder<'a> {
     ) -> HashMap<&'a str, HashMap<&'a str, &'a str>> {
         self.set_tag_attribute_values.clone()
     }
+
+    ///
+    pub fn allowed_attribute_prefix(&mut self, value: HashSet<&'a str>) -> &mut Self {
+        self.allowed_attribute_prefix = Some(value);
+        self
+    }
+
+    ///
+    pub fn add_allowed_attribute_prefix(&mut self, value: &'a str) -> &mut Self {
+        self.allowed_attribute_prefix
+            .get_or_insert_with(HashSet::new)
+            .insert(value);
+        self
+    }
+
+    ///
+    pub fn rm_allowed_attribute_prefix<'b, T: 'b + ?Sized + Borrow<str>, I: IntoIter<Item = &'b T>>(
+        &mut self,
+        it: I,
+    ) -> &mut Self {
+            self.allowed_attribute_prefix.as_mut()
+                .map(|prefixes| {
+                    for i in it {
+                        let _ = prefixes.remove(i.borrow());
+                    }
+                    prefixes
+                });
+        self
+    }
+
 
     /// Sets the attributes that are allowed on any tag.
     ///


### PR DESCRIPTION
This is a joint work with @shekyan, intend to solve #126 

**Background**
`data-` prefix is commonly used (such as google doc, etc.) and html sanitizers sometimes want to keep these attributes to support these interactive web apps. Before this commit, ammonia can only do exact match based attribute whitelist, instead of rule-based or prefix-based filtering.

**Proposed solution**
Added "prefix" based whitelist for generic attributes.
Introduced three new functions for Builder:

```rust
pub fn generic_attribute_prefixes(&mut self, value: HashSet<&'a str>) -> &mut Self;
pub fn add_generic_attribute_prefixes<T: 'a + ?Sized + Borrow<str>, I: IntoIter<Item = &'a T>>(
    &mut self,
    it: I,
) -> &mut Self;
pub fn rm_generic_attribute_prefixes<'b, T: 'b + ?Sized + Borrow<str>, I: IntoIter<Item = &'b T>>(
     &mut self,
     it: I,
) -> &mut Self;
pub fn clone_generic_attribute_prefixes(&self) -> Option<HashSet<&'a str>> {
    self.generic_attribute_prefixes.clone()
}
```

And put the prefix based whitelist logic along with the previous match:
```diff
@@ -1670,6 +1760,12 @@ impl<'a> Builder<'a> {
                 if self.tags.contains(&*name.local) {
                     let attr_filter = |attr: &html5ever::Attribute| {
                         let whitelisted = self.generic_attributes.contains(&*attr.name.local)
+                            || self
+                                .generic_attribute_prefixes
+                                .as_ref()
+                                .map(|prefixes| {
+                                    prefixes.iter().any(|&p| attr.name.local.starts_with(p))
+                                }) == Some(true)
                             || self
                                 .tag_attributes
                                 .get(&*name.local)
@@ -2850,4 +2946,43 @@ mod test {
             "&lt;this&gt;&#32;is&#32;&lt;a&#32;test&#32;function"
         );
     }
```

We added tests and doc-tests as well. Please feel free to comment and edit. Appreciate your help. Thanks!