### PR TITLE
Fix namespace switching bugs, release 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 3.1.2
+
+* fix: unexpected namespace switches can allow XSS via svg/mathml parsing
+
 # 3.1.1
 
 * fix: Crash on invalid URLs in some configurations ([issue #136](https://github.com/rust-ammonia/ammonia/issues/136))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 [`clean_text`]: https://docs.rs/ammonia/3.0.0/ammonia/fn.clean_text.html
 [rust-url 2.0]: https://docs.rs/url/2.0.0/url/
 
+# 2.1.3
+
+* fix: unexpected namespace switches can allow XSS via svg/mathml parsing (backported from 3.1.2)
+
 # 2.1.2
 
 * Fix a memory leak caused by certain node types.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ammonia"
-version = "3.1.1"
+version = "3.1.2"
 authors = ["Michael Howell <michael@notriddle.com>"]
 description = "HTML Sanitization"
 keywords = [ "sanitization", "html", "security", "xss" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1896,7 +1896,7 @@ impl<'a> Builder<'a> {
     // Check for unexpected namespace changes.
     //
     // The issue happens if developers added to the list of allowed tags any
-    // tag which is parsed in RCDATA state, PLAINTEXT state or RCDATA state,
+    // tag which is parsed in RCDATA state, PLAINTEXT state or RAWTEXT state,
     // that is:
     //
     // * title

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1901,12 +1901,14 @@ impl<'a> Builder<'a> {
     //
     // * title
     // * textarea
-    // * style
     // * xmp
     // * iframe
     // * noembed
     // * noframes
     // * plaintext
+    // * noscript
+    // * style
+    // * script
     //
     // An example in the wild is Plume, that allows iframe [1].  So in next
     // examples I'll assume the following policy:
@@ -1974,6 +1976,8 @@ impl<'a> Builder<'a> {
     // Elements which change namespace at an unexpected point are removed.
     // This function returns `true` if `child` should be kept, and `false` if it
     // should be removed.
+    //
+    // [1]: https://github.com/Plume-org/Plume/blob/main/plume-models/src/safe_string.rs#L21
     fn check_expected_namespace(&self, parent: &Handle, child: &Handle) -> bool {
         let (parent, child) = match (&parent.data, &child.data) {
             (NodeData::Element { name: pn, .. }, NodeData::Element { name: cn, .. }) => (pn, cn),


### PR DESCRIPTION
Reported as security vulnerability via private email.

The issue happens if developers added to the list of allowed tags any
tag which is parsed in RCDATA state, PLAINTEXT state or RCDATA state,
that is:

* title
* textarea
* xmp
* iframe
* noembed
* noframes
* plaintext
* noscript
* style
* script

An example in the wild is Plume, that allows iframe.  So in next
examples I'll assume the following policy:

    Builder::new()
       .add_tags(&["iframe"])

In HTML namespace `<iframe>` is parsed specially; that is, its content is
treated as text. For instance, the following html:

    <iframe><a>test

Is parsed into the following DOM tree:

    iframe
    └─ #text: <a>test

So iframe cannot have any children other than a text node.

The same is not true, though, in "foreign content"; that is, within
`<svg>` or `<math>` tags. The following html:

    <svg><iframe><a>test

is parsed differently:

    svg
    └─ iframe
       └─ a
          └─ #text: test

So in SVG namespace iframe can have children.

Ammonia disallows <svg> but it keeps its content after deleting it. And
the parser internally keeps track of the namespace of the element. So
assume we have the following snippet:

    <svg><iframe><a title="</iframe><img src onerror=alert(1)>">test

It is parsed into:

    svg
    └─ iframe
       └─ a title="</iframe><img src onerror=alert(1)>"
          └─ #text: test

This DOM tree is harmless from ammonia point of view because the piece
of code that looks like XSS is in a title attribute. Hence, the
resulting "safe" HTML from ammonia would be:

    <iframe><a title="</iframe><img src onerror=alert(1)>" rel="noopener noreferrer">test</a></iframe>

However, at this point, the information about namespace is lost, which
means that the browser will parse this snippet into:

    ├─ iframe
    │  └─ #text: <a title="
    ├─ img src="" onerror="alert(1)"
    └─ #text: " rel="noopener noreferrer">test

Leading to XSS.

To solve this issue, check for unexpected namespace switches after cleanup.
Elements which change namespace at an unexpected point are removed.
This function returns `true` if `child` should be kept, and `false` if it
should be removed.
