### PR TITLE
Fix a space bug in `clean_text`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: ["1.41.1", "stable", "beta"]
+        rust: ["1.48.0", "stable", "beta"]
         build_flags: ["", "--cfg ammonia_unstable"]
         os: [ubuntu-latest]
     steps:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ HTML Sanitization
 =================
 
 [![Crates.IO](https://img.shields.io/crates/v/ammonia.svg)](https://crates.rs/crates/ammonia)
-![Requires rustc 1.41.1](https://img.shields.io/badge/rustc-1.41.1+-green.svg)
+![Requires rustc 1.48.0](https://img.shields.io/badge/rustc-1.48.0+-green.svg)
 
 Ammonia is a whitelist-based HTML sanitization library. It is designed to
 prevent cross-site scripting, layout breaking, and clickjacking caused

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,8 @@ pub fn clean_text(src: &str) -> String {
             ' ' => "&#32;",
             '\t' => "&#9;",
             '\n' => "&#10;",
-            '\r' => "&#12;",
+            '\x0c' => "&#12;",
+            '\r' => "&#13;",
             // a spec-compliant browser will perform this replacement anyway, but the middleware might not
             '\0' => "&#65533;",
             // ALL OTHER CHARACTERS ARE PASSED THROUGH VERBATIM
@@ -3433,6 +3434,14 @@ mod test {
         assert_eq!(
             clean_text("<this> is <a test function"),
             "&lt;this&gt;&#32;is&#32;&lt;a&#32;test&#32;function"
+        );
+    }
+
+    #[test]
+    fn clean_text_spaces_test() {
+        assert_eq!(
+            clean_text("\x09\x0a\x0c\x20"),
+            "&#9;&#10;&#12;&#32;"
         );
     }
 


### PR DESCRIPTION
I mixed up FF with CR when reading an ASCII table. Bug reported via email.