### PR TITLE
Bump version to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Unreleased
 
+# 3.2.0
+
 * chore: bump MSRV to 1.49.0
 * chore: update to html5ever 0.26
+* chore: switch from lazy_static to once_cell
 * feature: add `Builder::empty()` constructor
 
 # 3.1.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ammonia"
-version = "3.1.4"
+version = "3.2.0"
 authors = ["Michael Howell <michael@notriddle.com>"]
 description = "HTML Sanitization"
 keywords = [ "sanitization", "html", "security", "xss" ]
@@ -16,7 +16,7 @@ html5ever = "0.26"
 maplit = "1.0"
 tendril = "0.4"
 url = "2"
-lazy_static = "1.3"
+once_cell = "1.10"
 
 [dev-dependencies]
 version-sync = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,8 @@ use html5ever::interface::Attribute;
 use html5ever::serialize::{serialize, SerializeOpts};
 use html5ever::tree_builder::{NodeOrText, TreeSink};
 use html5ever::{driver as html, local_name, namespace_url, ns, QualName};
-use lazy_static::lazy_static;
 use maplit::{hashmap, hashset};
+use once_cell::sync::Lazy;
 use rcdom::{Handle, NodeData, RcDom, SerializableHandle};
 use std::borrow::{Borrow, Cow};
 use std::cmp::max;
@@ -59,9 +59,7 @@ use html5ever::buffer_queue::BufferQueue;
 use html5ever::tokenizer::{Token, TokenSink, TokenSinkResult, Tokenizer};
 pub use url;
 
-lazy_static! {
-    static ref AMMONIA: Builder<'static> = Builder::default();
-}
+static AMMONIA: Lazy<Builder<'static>> = Lazy::new(|| Builder::default());
 
 /// Clean HTML with a conservative set of defaults.
 ///


### PR DESCRIPTION
This includes switching from the now-outdated lazy_static macro
to once_cell, which works without macros.