### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/rcdom.rs
+++ b/src/rcdom.rs
@@ -126,9 +126,9 @@ impl Node {
 
 impl Drop for Node {
     fn drop(&mut self) {
-        let mut nodes = mem::replace(&mut *self.children.borrow_mut(), vec![]);
+        let mut nodes = mem::take(&mut *self.children.borrow_mut());
         while let Some(node) = nodes.pop() {
-            let children = mem::replace(&mut *node.children.borrow_mut(), vec![]);
+            let children = mem::take(&mut *node.children.borrow_mut());
             nodes.extend(children.into_iter());
             if let NodeData::Element { ref template_contents, .. } = node.data {
                 if let Some(template_contents) = template_contents.borrow_mut().take() {
@@ -172,7 +172,7 @@ fn get_parent_and_index(target: &Handle) -> Option<(Handle, usize)> {
             .borrow()
             .iter()
             .enumerate()
-            .find(|&(_, child)| Rc::ptr_eq(&child, &target))
+            .find(|&(_, child)| Rc::ptr_eq(child, target))
         {
             Some((i, _)) => i,
             None => panic!("have parent but couldn't find in parent's children!"),
@@ -286,20 +286,16 @@ impl TreeSink for RcDom {
 
     fn append(&mut self, parent: &Handle, child: NodeOrText<Handle>) {
         // Append to an existing Text node if we have one.
-        match child {
-            NodeOrText::AppendText(ref text) => match parent.children.borrow().last() {
-                Some(h) => {
-                    if append_to_existing_text(h, &text) {
-                        return;
-                    }
-                },
-                _ => (),
-            },
-            _ => (),
+        if let NodeOrText::AppendText(ref text) = child {
+            if let Some(h) = parent.children.borrow().last() {
+                if append_to_existing_text(h, text) {
+                    return;
+                }
+            }
         }
 
         append(
-            &parent,
+            parent,
             match child {
                 NodeOrText::AppendText(text) => Node::new(NodeData::Text {
                     contents: RefCell::new(text),
@@ -310,7 +306,7 @@ impl TreeSink for RcDom {
     }
 
     fn append_before_sibling(&mut self, sibling: &Handle, child: NodeOrText<Handle>) {
-        let (parent, i) = get_parent_and_index(&sibling)
+        let (parent, i) = get_parent_and_index(sibling)
             .expect("append_before_sibling called on node without parent");
 
         let child = match (child, i) {
@@ -396,20 +392,20 @@ impl TreeSink for RcDom {
     }
 
     fn remove_from_parent(&mut self, target: &Handle) {
-        remove_from_parent(&target);
+        remove_from_parent(target);
     }
 
     fn reparent_children(&mut self, node: &Handle, new_parent: &Handle) {
         let mut children = node.children.borrow_mut();
         let mut new_children = new_parent.children.borrow_mut();
         for child in children.iter() {
-            let previous_parent = child.parent.replace(Some(Rc::downgrade(&new_parent)));
+            let previous_parent = child.parent.replace(Some(Rc::downgrade(new_parent)));
             assert!(Rc::ptr_eq(
-                &node,
+                node,
                 &previous_parent.unwrap().upgrade().expect("dangling weak")
             ))
         }
-        new_children.extend(mem::replace(&mut *children, Vec::new()));
+        new_children.extend(mem::take(&mut *children));
     }
 
     fn is_mathml_annotation_xml_integration_point(&self, target: &Handle) -> bool {
@@ -485,13 +481,13 @@ impl Serialize for SerializableHandle {
                         }
                     },
 
-                    NodeData::Doctype { ref name, .. } => serializer.write_doctype(&name)?,
+                    NodeData::Doctype { ref name, .. } => serializer.write_doctype(name)?,
 
                     NodeData::Text { ref contents } => {
                         serializer.write_text(&contents.borrow())?
                     },
 
-                    NodeData::Comment { ref contents } => serializer.write_comment(&contents)?,
+                    NodeData::Comment { ref contents } => serializer.write_comment(contents)?,
 
                     NodeData::ProcessingInstruction {
                         ref target,


### PR DESCRIPTION
This PR avoids fixing one clippy warning, since it's actually a breaking change.

```text
error: type `Document` implements inherent method `to_string(&self) -> String` which shadows the implementation of `Display`
    --> src/lib.rs:2670:5
     |
2670 | /     pub fn to_string(&self) -> String {
2671 | |         let opts = Self::serialize_opts();
2672 | |         let mut ret_val = Vec::new();
2673 | |         let inner: SerializableHandle = self.0.document.children.borrow()[0].clone().into();
...    |
2676 | |         String::from_utf8(ret_val).expect("html5ever only supports UTF8")
2677 | |     }
     | |_____^
     |
     = note: `#[deny(clippy::inherent_to_string_shadow_display)]` on by default
     = help: remove the inherent method from type `Document`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#inherent_to_string_shadow_display
```

This one will be fixed in version 4.