### PR TITLE
Doc: UrlRelativeEvaluate can be used with absolute URLs.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2675,9 +2675,7 @@ impl<'a> fmt::Debug for UrlRelative<'a> {
     }
 }
 
-/// Types that implement this trait can be used to convert a relative URL into an absolute URL.
-///
-/// This evaluator is only called when the URL is relative; absolute URLs are not evaluated.
+/// Types that implement this trait can be used to rewrite an URL with a custom function.
 ///
 /// See [`url_relative`][url_relative] for more details.
 ///


### PR DESCRIPTION
I noticed that the documentation says `UrlRelativeEvaluate::evaluate` is only called on relative URLs, but it is always called.