### PR TITLE
Update crates.rs README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 HTML Sanitization
 =================
 
-[![Crates.IO](https://img.shields.io/crates/v/ammonia.svg)](https://crates.rs/crates/ammonia)
+[![Crates.IO](https://img.shields.io/crates/v/ammonia.svg)](https://crates.io/crates/ammonia)
 ![Requires rustc 1.60.0](https://img.shields.io/badge/rustc-1.66.0+-green.svg)
 
 Ammonia is a whitelist-based HTML sanitization library. It is designed to


### PR DESCRIPTION
The [crates.rs page](https://crates.rs/crates/ammonia) says:

> The official crate repository is crates.io.
>
> crates.rs is a former domain name of the lib.rs website.
>
> Please update your links/bookmarks/habits, because the crates.rs domain will be phased out.

Per the message, I’ve updated the link to use crates.io (I don’t know the advantage of using lib.rs).