### PR TITLE
Clean up and test handling of customizable select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Unreleased
 
+* chore: upgrade to [html5ever 0.37.1][]
+
+* chore: always strip the contents of [`selectedcontent`][] elements,
+  since the parser will always replace it with the actual contents anyway
+
+[html5ever 0.37.1]: https://docs.rs/html5ever/0.37.1/html5ever/
+[`selectedcontent`]: https://html.spec.whatwg.org/#the-selectedcontent-element
+
 # 4.1.2
 
 * fix: unexpected namespace switches after cleanup can cause mXSS (reported by zzm0902@shu.edu.cn)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.80"
 
 [dependencies]
-html5ever = "0.37"
+html5ever = "0.37.1"
 maplit = "1.0"
 url = "2"
 cssparser = "0.36.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.80"
 
 [dependencies]
-html5ever = "0.37.1"
+html5ever = "0.38"
 maplit = "1.0"
 url = "2"
 cssparser = "0.36.0"

--- a/src/rcdom.rs
+++ b/src/rcdom.rs
@@ -425,26 +425,6 @@ impl TreeSink for RcDom {
             panic!("not an element!")
         }
     }
-
-    fn clone_subtree(&self, node_old: &Self::Handle) -> Self::Handle {
-        let node_new = Rc::new(Node {
-            parent: Cell::new(None),
-            children: RefCell::new(Vec::new()),
-            data: node_old.data.clone(),
-        });
-        *node_new.children.borrow_mut() =
-            node_old.children
-                .borrow()
-                .iter()
-                .map(|child_old| {
-                    let child_new = self.clone_subtree(&child_old);
-                    child_new.parent.set(Some(Rc::downgrade(&node_new)));
-                    child_new
-                })
-                .collect()
-        ;
-        node_new
-    }
 }
 
 impl Default for RcDom {


### PR DESCRIPTION
Becaue `<selectedcontent>`'s contents are always replaced by the browser when inserted, this patches the sanitizer to clear it entirely.

It also adds a test case, originally from the whatwg bug tracker, for handling a potential mxss in the select element.