### PR TITLE
Rename deeply_nested_* tests to express stack-overflow regression intent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2975,15 +2975,15 @@ impl From<Document> for String {
 mod test {
     use super::*;
     #[test]
-    fn deeply_nested_whitelisted() {
+    fn deeply_nested_whitelisted_does_not_cause_stack_overflow() {
         clean(&"<b>".repeat(60_000));
     }
     #[test]
-    fn deeply_nested_blacklisted() {
+    fn deeply_nested_blacklisted_does_not_cause_stack_overflow() {
         clean(&"<b-b>".repeat(60_000));
     }
     #[test]
-    fn deeply_nested_alternating() {
+    fn deeply_nested_alternating_does_not_cause_stack_overflow() {
         clean(&"<b-b>".repeat(35_000));
     }
     #[test]


### PR DESCRIPTION
## Summary

- Renames the three assertion-less `deeply_nested_*` tests in `src/lib.rs` so their name reflects their actual purpose (verifying the sanitizer does not stack-overflow on deeply nested input).
- Follows the existing `no_panic_*` convention already used elsewhere in the file.
- No behavior change — pure rename, zero impact on test coverage.

## Context

Per the discussion in #211, these tests look fallible at a glance because they have no assertion, but they exist specifically as regression guards against stack overflows (older versions of ammonia would crash on this input). The new names make that intent explicit in `cargo test` output.

Closes #211.

## Test plan

- [x] `cargo test --lib` — 86 passed, 0 failed
- [x] `cargo test` (lib + doctests + integration) — all green
- [x] `grep` confirms no other references to the old test names in the repo