### PR TITLE
Fix to_dom_node doctest by wrapping Handle in SerializableHandle

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2886,6 +2886,7 @@ impl Document {
     /// # Examples
     ///
     ///     use ammonia::Builder;
+    ///     use ammonia::rcdom::SerializableHandle;
     ///     use maplit::hashset;
     ///     use html5ever::serialize::{serialize, SerializeOpts};
     ///
@@ -2898,11 +2899,12 @@ impl Document {
     ///         .link_rel(None)
     ///         .clean(input);
     ///
-    ///     let mut node = document.to_dom_node();
+    ///     let node = document.to_dom_node();
     ///     node.children.borrow_mut().reverse();
     ///
     ///     let mut buf = Vec::new();
-    ///     serialize(&mut buf, &node, SerializeOpts::default())?;
+    ///     let handle: SerializableHandle = node.into();
+    ///     serialize(&mut buf, &handle, SerializeOpts::default())?;
     ///     let output = String::from_utf8(buf)?;
     ///
     ///     assert_eq!(output, expected);


### PR DESCRIPTION
## Summary
- The example for `Document::to_dom_node` passed a `Handle` directly to `html5ever::serialize::serialize`, but `serialize` requires a type implementing `Serialize`. `Handle` does not implement it; `SerializableHandle` does.
- The doctest is only compiled under `--cfg ammonia_unstable`, so the breakage went unnoticed by the default CI.
- Wrap the handle via `SerializableHandle::from(...)` (using `.into()` with a type annotation, matching the pattern already used internally in `Document::write_to` and `Document::to_string`).

Refs #190 (only the doctest fix part — stabilizing the API is out of scope here).

## Test plan
- [x] `RUSTFLAGS='--cfg ammonia_unstable' RUSTDOCFLAGS='--cfg ammonia_unstable' cargo test --doc` — `Document::to_dom_node` doctest now passes (68 passed total, previously 1 failed)
- [x] `cargo test` — default suite still green (67 doctests passed)