### PR TITLE
Release 3.3.3: Fix XSS caused by not sanitizing svg animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 3.3.3
+
+* fix: SVG `animation` and `set` can cause XSS, because `attributeName` is not checked (reported by Younghun Ko, koyokr)
+
 # 3.3.2
 
 * fix: unexpected namespace switches after cleanup on MathML `annotation-xml` can cause mXSS

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ammonia"
-version = "3.3.2"
+version = "3.3.3"
 authors = ["Michael Howell <michael@notriddle.com>"]
 description = "HTML Sanitization"
 keywords = [ "sanitization", "html", "security", "xss" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1792,6 +1792,8 @@ impl<'a> Builder<'a> {
             assert!(!self.tags.contains(tag_name));
             assert!(!self.tag_attributes.contains_key(tag_name));
         }
+        assert!(!self.tags.contains("animate"), "SVG animation is not supported: use 4.1.4 instead");
+        assert!(!self.tags.contains("set"), "SVG animation is not supported: use 4.1.4 instead");
         let body = {
             let children = dom.document.children.borrow();
             children[0].clone()
@@ -2194,6 +2196,10 @@ impl<'a> Builder<'a> {
 /// Given an element name and attribute name, determine if the given attribute contains a URL.
 fn is_url_attr(element: &str, attr: &str) -> bool {
     attr == "href"
+        // Don't have to worry about alternate xmlns prefixes, because HTML doesn't
+        // parse them, anyway:
+        // https://html.spec.whatwg.org/#adjust-foreign-attributes
+        || attr == "xlink:href"
         || attr == "src"
         || (element == "form" && attr == "action")
         || (element == "object" && attr == "data")
@@ -3593,6 +3599,20 @@ mod test {
     #[should_panic]
     fn panic_on_clean_content_tag() {
         Builder::new().clean_content_tags(hashset!["a"]).clean("");
+    }
+
+    // https://github.com/rust-ammonia/ammonia/security/advisories/GHSA-m6mh-2hw2-555x
+    #[test]
+    #[should_panic]
+    fn panic_on_allow_animate() {
+        Builder::new().add_tags(hashset!["animate"]).clean("");
+    }
+
+    // https://github.com/rust-ammonia/ammonia/security/advisories/GHSA-m6mh-2hw2-555x
+    #[test]
+    #[should_panic]
+    fn panic_on_allow_set() {
+        Builder::new().add_tags(hashset!["set"]).clean("");
     }
 
     #[test]


### PR DESCRIPTION
Fixes https://github.com/rust-ammonia/ammonia/security/advisories/GHSA-m6mh-2hw2-555x

The following SVG used to produce a link with a javascript scheme. If the user clicks this link, they will run it.

```xml
<svg xmlns="http://www.w3.org/2000/svg">
  <a>
    <set attributeName="href" to="javascript:alert('SET_XSS')"></set>
    <text y="30">Click set</text>
  </a>
</svg>
```